### PR TITLE
feat(failover): Enhance module to meet collection release standard (#83)

### DIFF
--- a/examples/playbooks/failover_config.yaml
+++ b/examples/playbooks/failover_config.yaml
@@ -1,0 +1,36 @@
+---
+- name: Example playbook to configure failover with cell modem
+  hosts: opengear
+  gather_facts: false
+
+  tasks:
+    - name: Gather current failover settings
+      opengear.ng.failover:
+        state: gathered
+      register: failover_facts
+
+    - name: Enable failover via wwan0, probing 8.8.8.8 and 1.1.1.1
+      opengear.ng.failover:
+        config:
+          enabled: true
+          probe_physif: net1
+          probe_address: 8.8.8.8
+          probe_address_2: 1.1.1.1
+          failover_physif: wwan0
+          dormant_dns: false
+        state: merged
+
+    - name: Replace failover settings (sends only specified fields)
+      opengear.ng.failover:
+        config:
+          enabled: true
+          probe_physif: net1
+          probe_address: 8.8.8.8
+          failover_physif: wwan0
+        state: replaced
+
+    - name: Disable failover
+      opengear.ng.failover:
+        config:
+          enabled: false
+        state: merged

--- a/plugins/module_utils/argspec/failover.py
+++ b/plugins/module_utils/argspec/failover.py
@@ -19,16 +19,25 @@ class FailoverArgs(object):  # pylint: disable=R0903
 
     argument_spec = {
         "config": {
+            "type": "dict",
             "options": {
                 "enabled": {"type": "bool"},
-                "probe_address": {"type": "str"},
                 "probe_physif": {"type": "str"},
+                "probe_address": {"type": "str"},
+                "probe_address_2": {"type": "str"},
+                "dormant_dns": {"type": "bool"},
+                "failover_physif": {"type": "str"},
             },
-            "type": "dict",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "gathered", "rendered"],
-            "default": "merged",
             "type": "str",
+            "default": "merged",
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "gathered",
+                "rendered",
+            ],
         },
     }  # pylint: disable=C0301

--- a/plugins/module_utils/config/failover.py
+++ b/plugins/module_utils/config/failover.py
@@ -8,13 +8,18 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from copy import deepcopy
+import json
+
+from ansible.module_utils.connection import ConnectionError
+
 from ansible_collections.opengear.ng.plugins.module_utils.config.base import ConfigBase
 from ansible_collections.opengear.ng.plugins.module_utils.facts.facts import Facts
 from ansible_collections.opengear.ng.plugins.module_utils.utils.utils import (
-    to_list,
-    dict_diff,
     dict_merge,
+    is_subset,
     remove_empties,
+    to_list,
 )
 
 
@@ -34,17 +39,20 @@ class Failover(ConfigBase):
 
     def __init__(self, module):
         super(Failover, self).__init__(module)
+        self.current_state = {}
 
-    def get_failover_facts(self):
+    def get_failover_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :rtype: A dictionary
         :returns: The current configuration as a dictionary
         """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts, _warnings = Facts(self._module).get_facts(
+            self.gather_subset, self.gather_network_resources, data
+        )
         failover_facts = facts['ansible_network_resources'].get('failover')
         if not failover_facts:
-            return []
+            return {}
         return failover_facts
 
     def execute_module(self):
@@ -61,34 +69,58 @@ class Failover(ConfigBase):
             existing_failover_facts = self.get_failover_facts()
         else:
             existing_failover_facts = {}
+
         if self.state in self.ACTION_STATES or self.state == 'rendered':
-            commands.extend(self.set_config(existing_failover_facts))
+            commands.extend(self.set_config(existing_failover_facts, warnings))
+
         if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 for command in commands:
                     try:
-                        self._connection.send_request(command['data'], command['path'], command['method'])
+                        self._connection.send_request(
+                            command['data'], command['path'], command['method']
+                        )
                     except ConnectionError as exc:
                         if not exc.args[0].startswith('Expecting value:'):
                             raise exc
+            else:
+                # Simulate state changes for check mode so result['after'] is accurate
+                self.current_state = deepcopy(existing_failover_facts)
+                for command in commands:
+                    self.current_state.update(command['data']['failover_settings'])
             result['changed'] = True
-        if self.state in self.ACTION_STATES:
-            result['commands'] = commands
+
+        result['commands'] = commands
+
         if self.state in self.ACTION_STATES or self.state == 'gathered':
-            changed_failover_facts = self.get_failover_facts()
+            if result['changed'] and self._module.check_mode:
+                # Use simulated state; device state is unchanged in check mode
+                changed_failover_facts = self.get_failover_facts(self.current_state or None)
+            else:
+                changed_failover_facts = self.get_failover_facts()
         elif self.state == 'rendered':
             result['rendered'] = commands
+
         if self.state in self.ACTION_STATES:
             result['before'] = existing_failover_facts
             if result['changed']:
                 result['after'] = changed_failover_facts
+                if self._module._diff:
+                    # Compute diff from command body so it is accurate in both
+                    # check mode and real mode
+                    cmd_body = commands[0]['data']['failover_settings'] if commands else {}
+                    diff_after = dict_merge(deepcopy(existing_failover_facts), cmd_body)
+                    result['diff'] = {
+                        'before': json.dumps(existing_failover_facts, indent=4) + '\n',
+                        'after': json.dumps(diff_after, indent=4) + '\n',
+                    }
         elif self.state == 'gathered':
             result['gathered'] = changed_failover_facts
 
         result['warnings'] = warnings
         return result
 
-    def set_config(self, existing_failover_facts):
+    def set_config(self, existing_failover_facts, warnings):
         """ Collect the configuration from the args passed to the module,
             collect the current configuration (as a dict from facts)
 
@@ -98,10 +130,10 @@ class Failover(ConfigBase):
         """
         want = self._module.params['config']
         have = existing_failover_facts
-        resp = self.set_state(want, have)
+        resp = self.set_state(want, have, warnings)
         return to_list(resp)
 
-    def set_state(self, want, have):
+    def set_state(self, want, have, warnings):
         """ Select the appropriate function based on the state provided
 
         :param want: the desired configuration as a dictionary
@@ -111,49 +143,54 @@ class Failover(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
-        if state == 'overridden':
-            commands = self._state_overridden(want, have)
+        if state in ('overridden', 'replaced'):
+            commands = self._state_replaced(want, have)
         elif state == 'merged':
             commands = self._state_merged(want, have)
-        elif state == 'replaced':
-            commands = self._state_replaced(want, have)
+        else:
+            commands = []
         return commands
 
     @staticmethod
     def _state_replaced(want, have):
-        """ The command generator when state is replaced
+        """ The command generator when state is replaced or overridden.
+
+        Sends exactly the specified config without merging with device state.
 
         :rtype: A list
-        :returns: the commands necessary to migrate the current configuration
-                  to the desired configuration
+        :returns: the commands necessary to set the desired configuration
         """
         commands = []
-        commands.extend(Failover._state_overridden(want, have))
-        return commands
-
-    @staticmethod
-    def _state_overridden(want, have):
-        """ The command generator when state is overridden
-
-        :rtype: A list
-        :returns: the commands necessary to migrate the current configuration
-                  to the desired configuration
-        """
-        commands = [{'data': {'failover_settings': want}, 'path': 'failover/settings', 'method': 'PUT'}]
+        want = remove_empties(want or {})
+        have = remove_empties(have or {})
+        if is_subset(want, have):
+            return commands
+        commands.append({
+            'data': {'failover_settings': want},
+            'path': 'failover/settings',
+            'method': 'PUT',
+        })
         return commands
 
     @staticmethod
     def _state_merged(want, have):
-        """ The command generator when state is merged
+        """ The command generator when state is merged.
+
+        Deep-merges want into the device state so unspecified fields are preserved.
 
         :rtype: A list
         :returns: the commands necessary to merge the provided into
                   the current configuration
         """
         commands = []
-        want = remove_empties(want)
-        have = remove_empties(have)
-        if dict_diff(want, have):
-            to_set = dict_merge(want, have)
-            commands.append({'data': {'failover_settings': to_set}, 'path': 'failover/settings', 'method': 'PUT'})
+        want = remove_empties(want or {})
+        have = remove_empties(have or {})
+        if is_subset(want, have):
+            return commands
+        merged = dict_merge(have, want)
+        commands.append({
+            'data': {'failover_settings': merged},
+            'path': 'failover/settings',
+            'method': 'PUT',
+        })
         return commands

--- a/plugins/modules/failover.py
+++ b/plugins/modules/failover.py
@@ -21,7 +21,9 @@ module: failover
 version_added: '1.0.0'
 short_description: Manages configuration of failover behavior on Opengear devices
 description:
-  - Manages configuration of failover behavior on Opengear devices
+  - Manages failover settings on Opengear devices.
+  - The failover resource is a singleton — only one set of settings exists on the device.
+  - C(replaced) and C(overridden) behave identically for this resource.
 author:
   - Opengear (@opengear)
 options:
@@ -30,36 +32,72 @@ options:
     type: dict
     suboptions:
       enabled:
+        description: Enable or disable failover.
         type: bool
-        description: failover enabled or disabled
       probe_physif:
-        description: A Failover event occurs if the probe_address is not reachable on this network interface.
+        description:
+          - The interface through which the device will attempt to probe I(probe_address).
+          - A failover event occurs if I(probe_address) is not reachable on this interface.
+          - Optional when failover is disabled.
         type: str
       probe_address:
-        description: Probe address can be an IPv4/6 address or hostname
+        description:
+          - Probe address; an IPv4 address, IPv6 address, or hostname.
+          - A failover event occurs if this address is not reachable via I(probe_physif).
+          - Be aware that hostnames may not resolve during failover depending on DNS settings.
         type: str
-
+      probe_address_2:
+        description:
+          - Secondary probe address; an IPv4 address, IPv6 address, or hostname.
+          - If configured, this address is probed via I(probe_physif) when I(probe_address)
+            is not reachable. A failover event occurs if this address is also not reachable.
+          - Be aware that hostnames may not resolve during failover depending on DNS settings.
+        type: str
+      dormant_dns:
+        description:
+          - When C(true), DNS is not configured for the failover interface during normal
+            operation. During failover, DNS is restored on that interface.
+        type: bool
+      failover_physif:
+        description:
+          - The network interface to fail over to.
+          - If this field is omitted when failover is enabled, it defaults to C(wwan0)
+            for compatibility with older releases.
+          - Optional when failover is disabled.
+        type: str
   state:
     description:
-    - The state of the configuration after module completion.
+      - The state of the configuration after module completion.
     type: str
     choices:
-    - merged
-    - replaced
-    - overridden
-    - gathered
-    - rendered
+      - merged
+      - replaced
+      - overridden
+      - gathered
+      - rendered
     default: merged
 """
 
 EXAMPLES = """
-- name: Configure failover
+- name: Enable failover, probing 8.8.8.8 and 1.1.1.1 via net1, failing over to wwan0
   opengear.ng.failover:
     config:
       enabled: true
-      probe_address: 8.8.8.8
       probe_physif: net1
+      probe_address: 8.8.8.8
+      probe_address_2: 1.1.1.1
+      failover_physif: wwan0
+      dormant_dns: false
     state: merged
+
+- name: Replace failover settings (sends only the specified fields)
+  opengear.ng.failover:
+    config:
+      enabled: true
+      probe_physif: net1
+      probe_address: 8.8.8.8
+      failover_physif: wwan0
+    state: replaced
 
 - name: Disable failover
   opengear.ng.failover:
@@ -67,7 +105,11 @@ EXAMPLES = """
       enabled: false
     state: merged
 
-- name: Gather failover facts
+- name: Gather current failover settings
+  opengear.ng.failover:
+    state: gathered
+
+- name: Gather failover facts via facts module
   opengear.ng.facts:
     gather_network_resources:
       - failover

--- a/tests/unit/modules/fixtures/failover_config.cfg
+++ b/tests/unit/modules/fixtures/failover_config.cfg
@@ -1,0 +1,8 @@
+{
+    "enabled": false,
+    "probe_physif": "net1",
+    "probe_address": "8.8.8.8",
+    "probe_address_2": "1.1.1.1",
+    "dormant_dns": false,
+    "failover_physif": "wwan0"
+}

--- a/tests/unit/modules/test_failover.py
+++ b/tests/unit/modules/test_failover.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import failover
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase, load_fixture
+
+
+class TestFailoverModule(TestModuleBase):
+
+    module = failover
+
+    def setUp(self):
+        super(TestFailoverModule, self).setUp()
+        self.maxDiff = None
+
+        self.mock_get_device_data = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "facts.failover.FailoverFacts.get_device_data"
+        )
+        self.get_device_data = self.mock_get_device_data.start()
+
+        self.mock_connection = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "config.base.Connection"
+        )
+        self.connection = self.mock_connection.start()
+
+    def tearDown(self):
+        super(TestFailoverModule, self).tearDown()
+        self.mock_get_device_data.stop()
+        self.mock_connection.stop()
+
+    def load_fixtures(self, commands=None):
+        def load_from_file(*args, **kwargs):
+            return load_fixture("failover_config.cfg")
+        self.get_device_data.side_effect = load_from_file
+
+    # ── Idempotency ──────────────────────────────────────────────────────────
+
+    def test_failover_merged_idempotent(self):
+        """No change when desired state already matches device."""
+        set_module_args({
+            'config': {
+                'enabled': False,
+                'probe_physif': 'net1',
+                'probe_address': '8.8.8.8',
+            },
+            'state': 'merged',
+        })
+        self.execute_module(changed=False, commands=[])
+
+    def test_failover_replaced_idempotent(self):
+        """No change when replaced config is a subset of device state."""
+        set_module_args({
+            'config': {
+                'enabled': False,
+                'probe_physif': 'net1',
+                'probe_address': '8.8.8.8',
+                'probe_address_2': '1.1.1.1',
+                'dormant_dns': False,
+                'failover_physif': 'wwan0',
+            },
+            'state': 'replaced',
+        })
+        self.execute_module(changed=False, commands=[])
+
+    # ── Merged state ─────────────────────────────────────────────────────────
+
+    def test_failover_merged_enable(self):
+        """Merged update enables failover and preserves unspecified fields."""
+        set_module_args({
+            'config': {
+                'enabled': True,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        cmd = result['commands'][0]
+        self.assertEqual(cmd['method'], 'PUT')
+        self.assertEqual(cmd['path'], 'failover/settings')
+        body = cmd['data']['failover_settings']
+        self.assertTrue(body['enabled'])
+        # Unspecified fields should be preserved from device state
+        self.assertEqual(body['probe_physif'], 'net1')
+        self.assertEqual(body['probe_address'], '8.8.8.8')
+
+    def test_failover_merged_update_probe_address_2(self):
+        """Merged update sets secondary probe address."""
+        set_module_args({
+            'config': {
+                'probe_address_2': '9.9.9.9',
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        body = result['commands'][0]['data']['failover_settings']
+        self.assertEqual(body['probe_address_2'], '9.9.9.9')
+        # Primary probe address preserved
+        self.assertEqual(body['probe_address'], '8.8.8.8')
+
+    def test_failover_merged_dormant_dns(self):
+        """Merged update sets dormant_dns flag."""
+        set_module_args({
+            'config': {
+                'dormant_dns': True,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        body = result['commands'][0]['data']['failover_settings']
+        self.assertTrue(body['dormant_dns'])
+
+    def test_failover_merged_failover_physif(self):
+        """Merged update sets failover_physif."""
+        set_module_args({
+            'config': {
+                'failover_physif': 'wwan1',
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        body = result['commands'][0]['data']['failover_settings']
+        self.assertEqual(body['failover_physif'], 'wwan1')
+
+    def test_failover_merged_preserves_device_fields(self):
+        """Merged sends a fully merged body so unspecified device fields are not lost."""
+        set_module_args({
+            'config': {
+                'enabled': True,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        body = result['commands'][0]['data']['failover_settings']
+        # All device fields should appear in the merged body
+        self.assertIn('probe_physif', body)
+        self.assertIn('probe_address', body)
+        self.assertIn('probe_address_2', body)
+        self.assertIn('failover_physif', body)
+
+    # ── Replaced / Overridden state ───────────────────────────────────────────
+
+    def test_failover_replaced_sends_only_specified_fields(self):
+        """Replaced sends exactly what is specified — no merging with device state."""
+        set_module_args({
+            'config': {
+                'enabled': True,
+                'probe_physif': 'net1',
+                'probe_address': '1.2.3.4',
+            },
+            'state': 'replaced',
+        })
+        result = self.execute_module(changed=True)
+        body = result['commands'][0]['data']['failover_settings']
+        self.assertEqual(body, {
+            'enabled': True,
+            'probe_physif': 'net1',
+            'probe_address': '1.2.3.4',
+        })
+        # Device-only fields must NOT appear (no implicit merge)
+        self.assertNotIn('probe_address_2', body)
+        self.assertNotIn('failover_physif', body)
+
+    def test_failover_overridden_same_as_replaced(self):
+        """Overridden behaves identically to replaced for a singleton resource."""
+        set_module_args({
+            'config': {
+                'enabled': True,
+                'probe_physif': 'net2',
+                'probe_address': '10.0.0.1',
+            },
+            'state': 'overridden',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        self.assertEqual(result['commands'][0]['method'], 'PUT')
+
+    # ── Gathered / Rendered ──────────────────────────────────────────────────
+
+    def test_failover_gathered(self):
+        """Gathered state returns current failover config from device."""
+        set_module_args({'state': 'gathered'})
+        result = self.execute_module(changed=False)
+        self.assertIn('gathered', result)
+        gathered = result['gathered']
+        self.assertEqual(gathered['enabled'], False)
+        self.assertEqual(gathered['probe_physif'], 'net1')
+        self.assertEqual(gathered['probe_address'], '8.8.8.8')
+        self.assertEqual(gathered['probe_address_2'], '1.1.1.1')
+        self.assertEqual(gathered['dormant_dns'], False)
+        self.assertEqual(gathered['failover_physif'], 'wwan0')
+
+    def test_failover_rendered(self):
+        """Rendered state generates commands without contacting the device."""
+        set_module_args({
+            'config': {
+                'enabled': True,
+                'probe_physif': 'net1',
+                'probe_address': '8.8.8.8',
+            },
+            'state': 'rendered',
+        })
+        result = self.execute_module(changed=False)
+        self.assertIn('rendered', result)
+        self.get_device_data.assert_not_called()
+
+    # ── Check mode ───────────────────────────────────────────────────────────
+
+    def test_failover_check_mode(self):
+        """Check mode generates commands but does not call send_request."""
+        set_module_args({
+            '_ansible_check_mode': True,
+            'config': {
+                'enabled': True,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+
+    # ── Diff mode ────────────────────────────────────────────────────────────
+
+    def test_failover_diff_merged_update(self):
+        """Diff output shows before and after for a merged update."""
+        set_module_args({
+            '_ansible_diff': True,
+            'config': {
+                'enabled': True,
+                'probe_address': '1.2.3.4',
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertFalse(before['enabled'])
+        self.assertTrue(after['enabled'])
+        self.assertEqual(after['probe_address'], '1.2.3.4')
+
+    def test_failover_no_diff_when_not_requested(self):
+        """Diff key is absent when _ansible_diff is not set."""
+        set_module_args({
+            'config': {'enabled': True},
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertNotIn('diff', result)
+
+    def test_failover_no_diff_when_idempotent(self):
+        """Diff key is absent when there are no changes."""
+        set_module_args({
+            '_ansible_diff': True,
+            'config': {
+                'enabled': False,
+                'probe_physif': 'net1',
+                'probe_address': '8.8.8.8',
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=False)
+        self.assertNotIn('diff', result)
+
+    def test_failover_check_mode_with_diff(self):
+        """Check mode with diff generates diff without sending commands."""
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': {
+                'enabled': True,
+                'probe_address': '9.9.9.9',
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.connection.return_value.send_request.assert_not_called()
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertFalse(before['enabled'])
+        self.assertTrue(after['enabled'])
+        self.assertEqual(after['probe_address'], '9.9.9.9')
+
+    # ── commands key always present ───────────────────────────────────────────
+
+    def test_failover_commands_always_present(self):
+        """result['commands'] is always present, even when there are no changes."""
+        set_module_args({
+            'config': {
+                'enabled': False,
+                'probe_physif': 'net1',
+                'probe_address': '8.8.8.8',
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=False)
+        self.assertIn('commands', result)
+        self.assertEqual(result['commands'], [])


### PR DESCRIPTION
The following improvements have been made to the failover module to meet the desired standard for release, following the groups module structure:

- Add --diff and --check mode support
- Add probe_address_2, dormant_dns, failover_physif fields from RAML spec
- Fix merged state logic (dict_merge argument order was reversed)
- Add idempotency checks to merged and replaced states
- Expand unit tests to cover all states, diff, and check mode
- Update module DOCUMENTATION and EXAMPLES with full field descriptions
- Add example playbook