### PR TITLE
ci: Allow external PR integration tests with approval

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,9 @@ jobs:
           # workflow_dispatch: use provided ref, or the branch the dispatch was triggered on
           # pull_request_target: always use the PR head SHA (not the base branch default)
           ref: ${{ inputs.pr_ref || github.event.pull_request.head.sha || github.sha }}
+          # Safe to opt in: the environment approval gate requires a human to review
+          # the PR code before this step runs, mitigating the pwn-request risk.
+          allow-unsafe-pr-checkout: true
 
       - name: Build inventory
         run: |


### PR DESCRIPTION
actions/checkout refuses to check out fork code in a pull_request_target context by default to prevent pwn-request attacks and requires a flag `allow-unsafe-pr-checkout: true`.

The integration test workflow requires manual approval via the integration-tests environment before any steps run, so a human has reviewed the code before checkout occurs, making this acceptable.