### PR TITLE
feat(auth): Enhance module to meet collection release standard (#84)

### DIFF
--- a/examples/playbooks/auth_config.yaml
+++ b/examples/playbooks/auth_config.yaml
@@ -1,11 +1,96 @@
 ---
+- name: Example playbook for managing authentication configuration
+  hosts: opengear
+  gather_facts: false
 
-- name: Configure Auth Config
-  hosts: all
-  connection: httpapi
   tasks:
-    - name: Change Auth
+    - name: Gather auth facts
+      opengear.ng.facts:
+        gather_network_resources:
+          - auth
+      register: auth_facts
+
+    - name: Show current auth configuration
+      ansible.builtin.debug:
+        var: auth_facts
+
+    # Reset to local authentication
+    - name: Set local authentication
       opengear.ng.auth:
         config:
           mode: local
         state: merged
+
+    # Configure LDAP authentication (replaces entire auth config)
+    - name: Configure LDAP authentication
+      opengear.ng.auth:
+        config:
+          mode: ldap
+          policy: remotedownlocal
+          timeout: 10
+          ldapBaseDN: "{{ ldap_base_dn | default('dc=example,dc=com') }}"
+          ldapBindDN: "{{ ldap_bind_dn | default('cn=admin,dc=example,dc=com') }}"
+          ldapBindPassword: "{{ ldap_bind_password }}"
+          ldapUsernameAttribute: uid
+          ldapGroupMembershipAttribute: memberOf
+          ldapIgnoreReferrals: false
+          ldapSslMode: ldaps_preferred
+          ldapAuthenticationServers:
+            - hostname: "{{ ldap_server_primary }}"
+              port: 389
+            - hostname: "{{ ldap_server_secondary | default(omit) }}"
+              port: 389
+        state: replaced
+      when: auth_mode | default('local') == 'ldap'
+
+    # Configure RADIUS authentication (replaces entire auth config)
+    - name: Configure RADIUS authentication
+      opengear.ng.auth:
+        config:
+          mode: radius
+          policy: remotedownlocal
+          timeout: 10
+          radiusMethod: pap
+          radiusPassword: "{{ radius_secret }}"
+          radiusAccountingEnabled: true
+          radiusRequireMessageAuthenticator: false
+          radiusAuthenticationServers:
+            - hostname: "{{ radius_server_primary }}"
+              port: 1812
+          radiusAccountingServers:
+            - hostname: "{{ radius_server_primary }}"
+              port: 1813
+        state: replaced
+      when: auth_mode | default('local') == 'radius'
+
+    # Configure TACACS+ authentication (replaces entire auth config)
+    - name: Configure TACACS+ authentication
+      opengear.ng.auth:
+        config:
+          mode: tacacs
+          policy: remotedownlocal
+          timeout: 10
+          tacacsMethod: pap
+          tacacsService: raccess
+          tacacsPassword: "{{ tacacs_secret }}"
+          tacacsAccountingEnabled: true
+          tacacsAuthenticationServers:
+            - hostname: "{{ tacacs_server_primary }}"
+              port: 49
+        state: replaced
+      when: auth_mode | default('local') == 'tacacs'
+
+    # Preview a config change without applying it
+    - name: Preview LDAP timeout change (check + diff mode)
+      opengear.ng.auth:
+        config:
+          timeout: 30
+        state: merged
+      check_mode: true
+      diff: true
+      register: auth_preview
+
+    - name: Show previewed change
+      ansible.builtin.debug:
+        var: auth_preview.diff
+      when: auth_preview.changed

--- a/plugins/module_utils/argspec/auth.py
+++ b/plugins/module_utils/argspec/auth.py
@@ -20,32 +20,16 @@ class AuthArgs(object):  # pylint: disable=R0903
     argument_spec = {
         "config": {
             "options": {
-                "ldapAuthenticationServers": {
-                    "elements": "dict",
-                    "options": {
-                        "hostname": {"type": "str"},
-                        "id": {"type": "str"},
-                        "port": {"type": "int"},
-                    },
-                    "type": "list",
+                "mode": {
+                    "type": "str",
+                    "choices": ["local", "radius", "tacacs", "ldap"],
                 },
-                "ldapBaseDN": {"type": "str"},
-                "ldapBindDN": {"type": "str"},
-                "ldapBindPassword": {"type": "str", "no_log": True},
-                "ldapGroupMembershipAttribute": {"type": "str"},
-                "ldapIgnoreReferals": {"type": "bool"},
-                "ldapUsernameAttribute": {"type": "str"},
-                "mode": {"type": "str"},
-                "policy": {"type": "str"},
-                "radiusAccountingServers": {
-                    "elements": "dict",
-                    "options": {
-                        "hostname": {"type": "str"},
-                        "id": {"type": "str"},
-                        "port": {"type": "int"},
-                    },
-                    "type": "list",
+                "policy": {
+                    "type": "str",
+                    "choices": ["remotedownlocal", "remotelocal"],
                 },
+                "timeout": {"type": "int"},
+                "radiusMethod": {"type": "str", "choices": ["pap", "mschapv2"]},
                 "radiusAuthenticationServers": {
                     "elements": "dict",
                     "options": {
@@ -55,7 +39,20 @@ class AuthArgs(object):  # pylint: disable=R0903
                     },
                     "type": "list",
                 },
+                "radiusAccountingServers": {
+                    "elements": "dict",
+                    "options": {
+                        "hostname": {"type": "str"},
+                        "id": {"type": "str"},
+                        "port": {"type": "int"},
+                    },
+                    "type": "list",
+                },
+                "radiusAccountingEnabled": {"type": "bool"},
+                "radiusRequireMessageAuthenticator": {"type": "bool"},
                 "radiusPassword": {"type": "str", "no_log": True},
+                "tacacsMethod": {"type": "str", "choices": ["pap", "chap", "login"]},
+                "tacacsService": {"type": "str"},
                 "tacacsAuthenticationServers": {
                     "elements": "dict",
                     "options": {
@@ -65,9 +62,29 @@ class AuthArgs(object):  # pylint: disable=R0903
                     },
                     "type": "list",
                 },
-                "tacacsMethod": {"type": "str"},
+                "tacacsAccountingEnabled": {"type": "bool"},
                 "tacacsPassword": {"type": "str", "no_log": True},
-                "tacacsService": {"type": "str"},
+                "ldapBaseDN": {"type": "str"},
+                "ldapBindDN": {"type": "str"},
+                "ldapBindPassword": {"type": "str", "no_log": True},
+                "ldapAuthenticationServers": {
+                    "elements": "dict",
+                    "options": {
+                        "hostname": {"type": "str"},
+                        "id": {"type": "str"},
+                        "port": {"type": "int"},
+                    },
+                    "type": "list",
+                },
+                "ldapUsernameAttribute": {"type": "str"},
+                "ldapGroupMembershipAttribute": {"type": "str"},
+                "ldapIgnoreReferrals": {"type": "bool"},
+                "ldapSslMode": {
+                    "type": "str",
+                    "choices": ["ldap_only", "ldaps_preferred", "ldaps_only"],
+                },
+                "ldapSslIgnoreCertErrors": {"type": "bool"},
+                "ldapSslCaCert": {"type": "str"},
             },
             "type": "dict",
         },

--- a/plugins/module_utils/config/auth.py
+++ b/plugins/module_utils/config/auth.py
@@ -8,13 +8,26 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import json
+from copy import deepcopy
+
+from ansible.module_utils.connection import ConnectionError
+
 from ansible_collections.opengear.ng.plugins.module_utils.config.base import ConfigBase
 from ansible_collections.opengear.ng.plugins.module_utils.facts.facts import Facts
 from ansible_collections.opengear.ng.plugins.module_utils.utils.utils import (
     to_list,
-    dict_diff,
-    dict_merge,
     remove_empties,
+)
+
+_SENSITIVE = frozenset({"radiusPassword", "tacacsPassword", "ldapBindPassword"})
+_SERVER_LISTS = frozenset(
+    {
+        "radiusAuthenticationServers",
+        "radiusAccountingServers",
+        "tacacsAuthenticationServers",
+        "ldapAuthenticationServers",
+    }
 )
 
 
@@ -23,37 +36,45 @@ class Auth(ConfigBase):
     Manages auth configuration for Opengear devices
     """
 
-    gather_subset = [
-        '!all',
-        '!min',
-    ]
-
-    gather_network_resources = [
-        'auth',
-    ]
+    gather_subset = ["!all", "!min"]
+    gather_network_resources = ["auth"]
 
     def __init__(self, module):
         super(Auth, self).__init__(module)
 
     def get_auth_facts(self):
-        """ Get the 'facts' (the current configuration)
-
-        :rtype: A dictionary
-        :returns: The current configuration as a dictionary
-        """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
-        auth_facts = facts['ansible_network_resources'].get('auth')
+        facts, _warnings = Facts(self._module).get_facts(
+            self.gather_subset, self.gather_network_resources
+        )
+        auth_facts = facts["ansible_network_resources"].get("auth")
         if not auth_facts:
-            return []
+            return {}
         return auth_facts
 
-    def execute_module(self):
-        """ Execute the module
+    def _simulate_after(self, existing, commands):
+        """Compute expected after state from commands without calling the API."""
+        if self.state in ("replaced", "overridden"):
+            # Full replacement: the command data IS the new state
+            simulated = {}
+            for command in commands:
+                if command["method"] == "PUT" and command["data"]:
+                    data = remove_empties(command["data"].get("auth", {}))
+                    for sf in _SENSITIVE:
+                        data.pop(sf, None)
+                    simulated = data
+        else:
+            # Merged: start from existing, overlay command fields
+            simulated = deepcopy(existing) if existing else {}
+            for command in commands:
+                if command["method"] == "PUT" and command["data"]:
+                    data = remove_empties(command["data"].get("auth", {}))
+                    for sf in _SENSITIVE:
+                        data.pop(sf, None)
+                    simulated.update(data)
+        return simulated
 
-        :rtype: A dictionary
-        :returns: The result from module execution
-        """
-        result = {'changed': False}
+    def execute_module(self):
+        result = {"changed": False}
         warnings = list()
         commands = list()
 
@@ -61,99 +82,86 @@ class Auth(ConfigBase):
             existing_auth_facts = self.get_auth_facts()
         else:
             existing_auth_facts = {}
-        if self.state in self.ACTION_STATES or self.state == 'rendered':
+
+        if self.state in self.ACTION_STATES or self.state == "rendered":
             commands.extend(self.set_config(existing_auth_facts))
+
         if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 for command in commands:
                     try:
-                        self._connection.send_request(command['data'], command['path'], command['method'])
+                        self._connection.send_request(
+                            command["data"], command["path"], command["method"]
+                        )
                     except ConnectionError as exc:
-                        if not exc.args[0].startswith('Expecting value:'):
+                        if not exc.args[0].startswith("Expecting value:"):
                             raise exc
-            result['changed'] = True
-        if self.state in self.ACTION_STATES:
-            result['commands'] = commands
-        if self.state in self.ACTION_STATES or self.state == 'gathered':
-            changed_auth_facts = self.get_auth_facts()
-        elif self.state == 'rendered':
-            result['rendered'] = commands
-        if self.state in self.ACTION_STATES:
-            result['before'] = existing_auth_facts
-            if result['changed']:
-                result['after'] = changed_auth_facts
-        elif self.state == 'gathered':
-            result['gathered'] = changed_auth_facts
+            result["changed"] = True
 
-        result['warnings'] = warnings
+        result["commands"] = commands
+
+        if self.state in self.ACTION_STATES or self.state == "gathered":
+            if self._module.check_mode and result["changed"]:
+                changed_auth_facts = self._simulate_after(existing_auth_facts, commands)
+            else:
+                changed_auth_facts = self.get_auth_facts()
+        elif self.state == "rendered":
+            result["rendered"] = commands
+
+        if self.state in self.ACTION_STATES:
+            result["before"] = existing_auth_facts
+            if result["changed"]:
+                result["after"] = changed_auth_facts
+                if self._module._diff:
+                    simulated = self._simulate_after(existing_auth_facts, commands)
+                    result["diff"] = {
+                        "before": json.dumps(existing_auth_facts or {}, indent=4)
+                        + "\n",
+                        "after": json.dumps(simulated, indent=4) + "\n",
+                    }
+        elif self.state == "gathered":
+            result["gathered"] = changed_auth_facts
+
+        result["warnings"] = warnings
         return result
 
     def set_config(self, existing_auth_facts):
-        """ Collect the configuration from the args passed to the module,
-            collect the current configuration (as a dict from facts)
-
-        :rtype: A list
-        :returns: the commands necessary to migrate the current configuration
-                  to the desired configuration
-        """
-        want = self._module.params['config']
+        want = self._module.params["config"]
         have = existing_auth_facts
         resp = self.set_state(want, have)
         return to_list(resp)
 
     def set_state(self, want, have):
-        """ Select the appropriate function based on the state provided
-
-        :param want: the desired configuration as a dictionary
-        :param have: the current configuration as a dictionary
-        :rtype: A list
-        :returns: the commands necessary to migrate the current configuration
-                  to the desired configuration
-        """
-        state = self._module.params['state']
-        if state == 'overridden':
-            commands = self._state_overridden(want, have)
-        elif state == 'merged':
-            commands = self._state_merged(want, have)
-        elif state == 'replaced':
-            commands = self._state_replaced(want, have)
-        return commands
+        state = self._module.params["state"]
+        if state in ("overridden", "replaced"):
+            return self._state_replaced(want, have)
+        elif state == "merged":
+            return self._state_merged(want, have)
+        return []
 
     @staticmethod
     def _state_replaced(want, have):
-        """ The command generator when state is replaced
-
-        :rtype: A list
-        :returns: the commands necessary to migrate the current configuration
-                  to the desired configuration
-        """
-        commands = []
-        commands.extend(Auth._state_overridden(want, have))
-        return commands
-
-    @staticmethod
-    def _state_overridden(want, have):
-        """ The command generator when state is overridden
-
-        :rtype: A list
-        :returns: the commands necessary to migrate the current configuration
-                  to the desired configuration
-        """
-        commands = [{'data': {'auth': want}, 'path': 'auth', 'method': 'PUT'}]
-        return commands
+        want = remove_empties(want)
+        have = remove_empties(have)
+        has_sensitive = any(k in want for k in _SENSITIVE)
+        want_compare = {k: v for k, v in want.items() if k not in _SENSITIVE}
+        have_compare = {k: v for k, v in have.items() if k not in _SENSITIVE}
+        if want_compare != have_compare or has_sensitive:
+            return [{"data": {"auth": want}, "path": "auth", "method": "PUT"}]
+        return []
 
     @staticmethod
     def _state_merged(want, have):
-        """ The command generator when state is merged
-
-        :rtype: A list
-        :returns: the commands necessary to merge the provided into
-                  the current configuration
-        """
-        commands = []
         want = remove_empties(want)
         have = remove_empties(have)
-        if dict_diff(want, have):
-            to_set = dict_merge(want, have)
-            commands.append({'data': {'auth': to_set}, 'path': 'auth', 'method': 'PUT'})
-        return commands
+        merged = {**have, **want}
+        has_skip = any(k in want for k in _SENSITIVE | _SERVER_LISTS)
+        merged_compare = {
+            k: v for k, v in merged.items() if k not in (_SENSITIVE | _SERVER_LISTS)
+        }
+        have_compare = {
+            k: v for k, v in have.items() if k not in (_SENSITIVE | _SERVER_LISTS)
+        }
+        if merged_compare != have_compare or has_skip:
+            return [{"data": {"auth": merged}, "path": "auth", "method": "PUT"}]
+        return []

--- a/plugins/module_utils/facts/auth.py
+++ b/plugins/module_utils/facts/auth.py
@@ -19,7 +19,7 @@ class AuthFacts(object):
     Retrieves and parses auth configuration facts from Opengear devices.
     """
 
-    def __init__(self, module, subspec='config', options='options'):
+    def __init__(self, module, subspec="config", options="options"):
         self._module = module
         self.argument_spec = AuthArgs.argument_spec
         spec = deepcopy(self.argument_spec)
@@ -34,10 +34,10 @@ class AuthFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_device_data(self, connection):
-        return connection.get(None, 'auth')['auth']
+        return connection.get(None, "auth")["auth"]
 
     def populate_facts(self, connection, ansible_facts, data=None):
-        """ Populate the facts for auth
+        """Populate the facts for auth
         :param connection: the device connection
         :param ansible_facts: Facts dictionary
         :param data: previously collected conf
@@ -52,15 +52,15 @@ class AuthFacts(object):
         if data:
             obj.update(self.render_config(self.generated_spec, data))
 
-        ansible_facts['ansible_network_resources'].pop('auth', None)
+        ansible_facts["ansible_network_resources"].pop("auth", None)
         facts = {}
         if obj:
-            params = utils.validate_config(self.argument_spec, {'config': obj})
-            facts['auth'] = params['config']
+            params = utils.validate_config(self.argument_spec, {"config": obj})
+            facts["auth"] = params["config"]
         else:
-            facts['auth'] = {}
+            facts["auth"] = {}
 
-        ansible_facts['ansible_network_resources'].update(facts)
+        ansible_facts["ansible_network_resources"].update(facts)
         return ansible_facts
 
     def render_config(self, spec, conf):
@@ -73,8 +73,8 @@ class AuthFacts(object):
         :rtype: dictionary
         :returns: The generated config
         """
-        config = deepcopy(spec)
-        for option in config.keys():
+        config = {}
+        for option in spec.keys():
             if option in conf:
                 config[option] = conf[option]
         return utils.remove_empties(config)

--- a/plugins/modules/auth.py
+++ b/plugins/modules/auth.py
@@ -21,7 +21,8 @@ module: auth
 version_added: '1.0.0'
 short_description: Manages auth configuration for Opengear devices
 description:
-  - Manages auth configuration for Opengear devices
+  - Manages authentication configuration for Opengear devices, including local,
+    RADIUS, TACACS+, and LDAP authentication modes.
 author:
   - Opengear (@opengear)
 options:
@@ -31,99 +32,135 @@ options:
     suboptions:
       mode:
         type: str
-        description: auth mode
+        description: Authentication mode
+        choices: ['local', 'radius', 'tacacs', 'ldap']
       policy:
-        description: Check local credentials after remote auth failure.
+        description: |
+          Fallback policy for remote authentication.
+          C(remotedownlocal) falls back to local only when the remote server is unreachable.
+          C(remotelocal) always checks local credentials after remote authentication.
         type: str
-      tacacsMethod:
+        choices: ['remotedownlocal', 'remotelocal']
+      timeout:
+        type: int
+        description: Timeout in seconds for remote authentication server responses (1-3600).
+      radiusMethod:
         type: str
-        description: tacacs method
-      tacacsService:
-        type: str
-        description: tacacs service
-      ldapBaseDN:
-        type: str
-        description: ldap base dn
-      ldapBindDN:
-        type: str
-        description: ldap bind dn
-      ldapIgnoreReferals:
-        type: bool
-        description: ldap ignore referrals
-      ldapUsernameAttribute:
-        type: str
-        description: ldap username
-      ldapGroupMembershipAttribute:
-        type: str
-        description: ldap group member
+        description: RADIUS authentication method.
+        choices: ['pap', 'mschapv2']
       radiusAuthenticationServers:
         type: list
-        description: radius auth servers
+        description: List of RADIUS authentication servers.
         elements: dict
         suboptions:
           id:
             type: str
-            description: id
+            description: Server ID (read-only, assigned by device).
           hostname:
             type: str
-            description: hostname or address
+            description: Hostname or IP address of the RADIUS server.
           port:
             type: int
-            description: radius port
+            description: UDP port for the RADIUS server.
       radiusAccountingServers:
         type: list
-        description: radius accounting server
+        description: List of RADIUS accounting servers.
         elements: dict
         suboptions:
           id:
             type: str
-            description: id
+            description: Server ID (read-only, assigned by device).
           hostname:
             type: str
-            description: hostname or address
+            description: Hostname or IP address of the RADIUS accounting server.
           port:
             type: int
-            description: port
-      tacacsAuthenticationServers:
-        type: list
-        description: tacacs auth server
-        elements: dict
-        suboptions:
-          id:
-            type: str
-            description: id
-          hostname:
-            type: str
-            description: hostname or address
-          port:
-            type: int
-            description: port
-      ldapAuthenticationServers:
-        type: list
-        description: ldap auth server
-        elements: dict
-        suboptions:
-          id:
-            type: str
-            description: id
-          hostname:
-            type: str
-            description: hostname or address
-          port:
-            type: int
-            description: port
+            description: UDP port for the RADIUS accounting server.
+      radiusAccountingEnabled:
+        type: bool
+        description: Enable RADIUS accounting.
+      radiusRequireMessageAuthenticator:
+        type: bool
+        description: Require the Message-Authenticator attribute in RADIUS responses.
       radiusPassword:
         type: str
-        description: radius password
+        description: Shared secret for RADIUS servers. Write-only; not returned by the device.
+      tacacsMethod:
+        type: str
+        description: TACACS+ authentication method.
+        choices: ['pap', 'chap', 'login']
+      tacacsService:
+        type: str
+        description: TACACS+ service type (default C(raccess)).
+      tacacsAuthenticationServers:
+        type: list
+        description: List of TACACS+ authentication servers.
+        elements: dict
+        suboptions:
+          id:
+            type: str
+            description: Server ID (read-only, assigned by device).
+          hostname:
+            type: str
+            description: Hostname or IP address of the TACACS+ server.
+          port:
+            type: int
+            description: TCP port for the TACACS+ server.
+      tacacsAccountingEnabled:
+        type: bool
+        description: Enable TACACS+ accounting.
       tacacsPassword:
         type: str
-        description: tacacs password
+        description: Shared secret for TACACS+ servers. Write-only; not returned by the device.
+      ldapBaseDN:
+        type: str
+        description: Base DN for LDAP searches.
+      ldapBindDN:
+        type: str
+        description: Bind DN used for LDAP authentication.
       ldapBindPassword:
         type: str
-        description: ldap bind password
+        description: Password for the LDAP bind DN. Write-only; not returned by the device.
+      ldapAuthenticationServers:
+        type: list
+        description: List of LDAP authentication servers.
+        elements: dict
+        suboptions:
+          id:
+            type: str
+            description: Server ID (read-only, assigned by device).
+          hostname:
+            type: str
+            description: Hostname or IP address of the LDAP server.
+          port:
+            type: int
+            description: TCP port for the LDAP server.
+      ldapUsernameAttribute:
+        type: str
+        description: LDAP attribute used to match the username.
+      ldapGroupMembershipAttribute:
+        type: str
+        description: LDAP attribute used to determine group membership.
+      ldapIgnoreReferrals:
+        type: bool
+        description: Ignore LDAP referrals during authentication.
+      ldapSslMode:
+        type: str
+        description: SSL/TLS mode for LDAP connections.
+        choices: ['ldap_only', 'ldaps_preferred', 'ldaps_only']
+      ldapSslIgnoreCertErrors:
+        type: bool
+        description: Ignore SSL certificate validation errors for LDAP connections.
+      ldapSslCaCert:
+        type: str
+        description: CA certificate (PEM format) used to validate the LDAP server's SSL certificate.
   state:
     description:
     - The state of the configuration after module completion.
+    - C(merged) merges the provided config into the existing config; want fields overwrite have fields.
+    - C(replaced) and C(overridden) fully replace the auth config with the provided values.
+    - C(gathered) retrieves the current auth configuration from the device.
+    - C(rendered) generates commands without connecting to a device.
     type: str
     choices:
     - merged
@@ -132,32 +169,103 @@ options:
     - gathered
     - rendered
     default: merged
+notes:
+  - Diff output shows the expected configuration change based on the commands
+    generated. It does not reflect the actual device state after execution,
+    which may differ due to device-side normalization or concurrent changes.
+    Use state=gathered after a run to verify the actual device state.
+  - Sensitive fields (radiusPassword, tacacsPassword, ldapBindPassword) are
+    write-only; they are never returned by the device and will not appear in
+    diff or after output. Specifying a sensitive field always triggers a PUT
+    even if no other fields changed.
+  - Server list fields (radiusAuthenticationServers, radiusAccountingServers,
+    tacacsAuthenticationServers, ldapAuthenticationServers) always trigger a
+    PUT when specified in merged state, since device-assigned id fields prevent
+    reliable idempotency comparison.
 """
 
 EXAMPLES = """
+- name: Gather auth facts
+  opengear.ng.facts:
+    gather_network_resources:
+      - auth
+  register: auth_facts
+
+- name: Show auth facts
+  ansible.builtin.debug:
+    var: auth_facts
+
+- name: Set local authentication
+  opengear.ng.auth:
+    config:
+      mode: local
+    state: merged
+
 - name: Configure LDAP authentication
   opengear.ng.auth:
     config:
       mode: ldap
-      policy: remotelocal
+      policy: remotedownlocal
       timeout: 10
       ldapBaseDN: dc=example,dc=com
       ldapBindDN: cn=admin,dc=example,dc=com
-      ldapIgnoreReferrals: true
-      ldapUsernameAttribute: uid
-      ldapGroupMembershipAttribute: gid
       ldapBindPassword: "{{ ldap_bind_password }}"
+      ldapUsernameAttribute: uid
+      ldapGroupMembershipAttribute: memberOf
+      ldapIgnoreReferrals: false
+      ldapSslMode: ldaps_preferred
       ldapAuthenticationServers:
         - hostname: ldap.example.com
           port: 389
         - hostname: ldap2.example.com
           port: 389
-    state: merged
+    state: replaced
 
-- name: Gather auth facts
-  opengear.ng.facts:
-    gather_network_resources:
-      - auth
+- name: Configure RADIUS authentication
+  opengear.ng.auth:
+    config:
+      mode: radius
+      policy: remotedownlocal
+      timeout: 10
+      radiusMethod: pap
+      radiusPassword: "{{ radius_secret }}"
+      radiusAccountingEnabled: true
+      radiusRequireMessageAuthenticator: false
+      radiusAuthenticationServers:
+        - hostname: radius.example.com
+          port: 1812
+      radiusAccountingServers:
+        - hostname: radius.example.com
+          port: 1813
+    state: replaced
+
+- name: Configure TACACS+ authentication
+  opengear.ng.auth:
+    config:
+      mode: tacacs
+      policy: remotedownlocal
+      timeout: 10
+      tacacsMethod: pap
+      tacacsService: raccess
+      tacacsPassword: "{{ tacacs_secret }}"
+      tacacsAccountingEnabled: true
+      tacacsAuthenticationServers:
+        - hostname: tacacs.example.com
+          port: 49
+    state: replaced
+
+- name: Preview LDAP config change without applying (check mode)
+  opengear.ng.auth:
+    config:
+      mode: ldap
+      ldapBaseDN: dc=example,dc=com
+      ldapUsernameAttribute: uid
+      ldapAuthenticationServers:
+        - hostname: ldap.example.com
+          port: 389
+    state: merged
+  check_mode: true
+  diff: true
 """
 
 RETURN = """
@@ -173,6 +281,12 @@ commands:
   description: The set of commands pushed to the remote device.
   returned: always
   type: list
+diff:
+  description: |
+    The expected configuration change. Sensitive fields are omitted.
+    This reflects the commands generated, not the actual device state.
+  returned: when changed and diff mode is enabled
+  type: dict
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/unit/modules/fixtures/auth_config.cfg
+++ b/tests/unit/modules/fixtures/auth_config.cfg
@@ -1,0 +1,5 @@
+{
+    "mode": "local",
+    "policy": "remotelocal",
+    "timeout": 10
+}

--- a/tests/unit/modules/test_auth.py
+++ b/tests/unit/modules/test_auth.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import auth
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase, load_fixture
+
+
+class TestAuthModule(TestModuleBase):
+
+    module = auth
+
+    def setUp(self):
+        super(TestAuthModule, self).setUp()
+        self.maxDiff = None
+
+        self.mock_get_device_data = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "facts.auth.AuthFacts.get_device_data"
+        )
+        self.get_device_data = self.mock_get_device_data.start()
+
+        self.mock_connection = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "config.base.Connection"
+        )
+        self.connection = self.mock_connection.start()
+
+    def tearDown(self):
+        super(TestAuthModule, self).tearDown()
+        self.mock_get_device_data.stop()
+        self.mock_connection.stop()
+
+    def load_fixtures(self, commands=None):
+        self.get_device_data.side_effect = lambda *a, **kw: load_fixture("auth_config.cfg")
+
+    # --- merged state ---
+
+    def test_auth_merged_noop(self):
+        set_module_args({
+            'config': {
+                'mode': 'local',
+                'policy': 'remotelocal',
+                'timeout': 10,
+            },
+            'state': 'merged',
+        })
+        self.execute_module(changed=False, commands=[])
+
+    def test_auth_merged_change_timeout(self):
+        set_module_args({
+            'config': {
+                'timeout': 30,
+            },
+            'state': 'merged',
+        })
+        commands = [
+            {
+                'path': 'auth',
+                'data': {
+                    'auth': {
+                        'mode': 'local',
+                        'policy': 'remotelocal',
+                        'timeout': 30,
+                    }
+                },
+                'method': 'PUT',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_auth_merged_change_mode(self):
+        set_module_args({
+            'config': {
+                'mode': 'ldap',
+                'policy': 'remotedownlocal',
+                'ldapBaseDN': 'dc=example,dc=com',
+                'ldapUsernameAttribute': 'uid',
+                'ldapAuthenticationServers': [
+                    {'hostname': 'ldap.example.com', 'port': 389}
+                ],
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        cmd = result['commands'][0]
+        self.assertEqual(cmd['method'], 'PUT')
+        self.assertEqual(cmd['path'], 'auth')
+        auth_data = cmd['data']['auth']
+        self.assertEqual(auth_data['mode'], 'ldap')
+        self.assertEqual(auth_data['ldapBaseDN'], 'dc=example,dc=com')
+        self.assertIn('ldapAuthenticationServers', auth_data)
+
+    def test_auth_merged_with_ldap_servers_always_updates(self):
+        """Server list fields always trigger a PUT in merged mode."""
+        set_module_args({
+            'config': {
+                'ldapAuthenticationServers': [
+                    {'hostname': 'ldap.example.com', 'port': 389}
+                ],
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+
+    # --- replaced / overridden state ---
+
+    def test_auth_replaced(self):
+        """replaced with different timeout and missing policy removes policy."""
+        set_module_args({
+            'config': {
+                'mode': 'local',
+                'timeout': 20,
+            },
+            'state': 'replaced',
+        })
+        commands = [
+            {
+                'path': 'auth',
+                'data': {
+                    'auth': {
+                        'mode': 'local',
+                        'timeout': 20,
+                    }
+                },
+                'method': 'PUT',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_auth_replaced_noop(self):
+        set_module_args({
+            'config': {
+                'mode': 'local',
+                'policy': 'remotelocal',
+                'timeout': 10,
+            },
+            'state': 'replaced',
+        })
+        self.execute_module(changed=False, commands=[])
+
+    def test_auth_overridden(self):
+        """overridden behaves the same as replaced."""
+        set_module_args({
+            'config': {
+                'mode': 'local',
+                'timeout': 20,
+            },
+            'state': 'overridden',
+        })
+        commands = [
+            {
+                'path': 'auth',
+                'data': {
+                    'auth': {
+                        'mode': 'local',
+                        'timeout': 20,
+                    }
+                },
+                'method': 'PUT',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    # --- gathered / rendered ---
+
+    def test_auth_gathered(self):
+        set_module_args({
+            'state': 'gathered',
+        })
+        result = self.execute_module(changed=False)
+        self.assertIn('gathered', result)
+        gathered = result['gathered']
+        self.assertEqual(gathered['mode'], 'local')
+        self.assertEqual(gathered['policy'], 'remotelocal')
+        self.assertEqual(gathered['timeout'], 10)
+
+    def test_auth_rendered(self):
+        set_module_args({
+            'config': {
+                'mode': 'ldap',
+                'ldapBaseDN': 'dc=example,dc=com',
+            },
+            'state': 'rendered',
+        })
+        self.execute_module(changed=False, commands=[])
+
+    # --- check mode ---
+
+    def test_auth_check_mode(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            'config': {
+                'timeout': 30,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+
+    # --- diff mode ---
+
+    def test_auth_diff_merged(self):
+        set_module_args({
+            '_ansible_diff': True,
+            'config': {
+                'timeout': 30,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(before['timeout'], 10)
+        self.assertEqual(after['timeout'], 30)
+        self.assertEqual(before['mode'], 'local')
+        self.assertEqual(after['mode'], 'local')
+
+    def test_auth_no_diff_when_not_requested(self):
+        set_module_args({
+            'config': {
+                'timeout': 30,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertNotIn('diff', result)
+
+    def test_auth_no_diff_when_idempotent(self):
+        set_module_args({
+            '_ansible_diff': True,
+            'config': {
+                'mode': 'local',
+                'policy': 'remotelocal',
+                'timeout': 10,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=False)
+        self.assertNotIn('diff', result)
+
+    # --- check mode + diff ---
+
+    def test_auth_check_mode_with_diff(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': {
+                'timeout': 30,
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(before['timeout'], 10)
+        self.assertEqual(after['timeout'], 30)
+        self.assertNotEqual(before['timeout'], after['timeout'])
+
+    def test_auth_check_mode_with_diff_replaced(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': {
+                'mode': 'local',
+                'timeout': 20,
+            },
+            'state': 'replaced',
+        })
+        result = self.execute_module(changed=True)
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(before['timeout'], 10)
+        self.assertEqual(after['timeout'], 20)
+        # policy was in before but not in after (replaced removes it)
+        self.assertIn('policy', before)
+        self.assertNotIn('policy', after)
+
+    def test_auth_sensitive_field_not_in_diff(self):
+        """Sensitive fields must not appear in diff output."""
+        set_module_args({
+            '_ansible_diff': True,
+            'config': {
+                'mode': 'radius',
+                'radiusPassword': 's3cr3t',
+                'radiusAuthenticationServers': [
+                    {'hostname': 'radius.example.com', 'port': 1812}
+                ],
+            },
+            'state': 'merged',
+        })
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        after = json.loads(result['diff']['after'])
+        self.assertNotIn('radiusPassword', after)


### PR DESCRIPTION
The following improvements have been made to the auth module to meet the desired standard for release:

- Add all fields from current API spec
- Add enum choices to mode, policy, radiusMethod, tacacsMethod, ldapSslMode
- Fix merged state logic (dict_merge argument order was reversed)
- Fix facts render_config to only include fields present in device response
- Sensitive fields excluded from diff; server lists always trigger PUT when specified
- Add check mode simulation and diff mode output
- Expand unit tests to cover all states, diff, and check mode
- Update module DOCUMENTATION and EXAMPLES with full field descriptions
- Add example playbook