### PR TITLE
ci: Restrict PR integration tests to upstream repo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,8 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: [self-hosted, ansible, integration-tests]
+    # Only run on upstream repository
+    if: github.repository == 'opengear/ansible-ng'
     # All PRs require manual approval via the integration-tests environment
     # to serialise access to the single shared test device.
     environment: ${{ github.event_name == 'pull_request_target' && 'integration-tests' || '' }}


### PR DESCRIPTION
Prevent integration test job from queuing indefinitely on forks by gating automatic runs to opengear/ansible-ng only.

Manual workflow_dispatch trigger remains available for contributors with their own runner and environment.